### PR TITLE
indexing error

### DIFF
--- a/src/msttransforms.cpp
+++ b/src/msttransforms.cpp
@@ -308,7 +308,6 @@ void Transform::apply(mstreal& x, mstreal& y, mstreal& z) {
   p[0] = 0;
   p[1] = 0;
   p[2] = 0;
-  p[3] = 0;
   for (int i = 0; i < 3; i++) {
     p[i] += (*this)(i, 0) * x;
     p[i] += (*this)(i, 1) * y;


### PR DESCRIPTION
fixed vector index access bug in new msttransforms that resulted in a stack smashing error on Linux and Mac M1